### PR TITLE
✨feat: 회원 정보 수정 [DRKKO-38]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ repositories {
 
 dependencies {
     // https://mvnrepository.com/artifact/org.json/json
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.3.1'
+
     implementation group: 'org.json', name: 'json', version: '20220924'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/src/main/java/com/musicq/musicqservice/config/AwsS3Config.java
+++ b/src/main/java/com/musicq/musicqservice/config/AwsS3Config.java
@@ -1,0 +1,31 @@
+package com.musicq.musicqservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class AwsS3Config {
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+		return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+			.build();
+	}
+}

--- a/src/main/java/com/musicq/musicqservice/member/controller/LoginController.java
+++ b/src/main/java/com/musicq/musicqservice/member/controller/LoginController.java
@@ -1,6 +1,5 @@
 package com.musicq.musicqservice.member.controller;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.musicq.musicqservice.member.dto.LoginDto;
-import com.musicq.musicqservice.member.dto.LoginResDto;
+import com.musicq.musicqservice.member.dto.ResultResDto;
 import com.musicq.musicqservice.member.service.LoginService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,21 +25,21 @@ public class LoginController {
 
 	// 로컬 로그인
 	@PostMapping("/login")
-	public ResponseEntity<LoginResDto> login(
+	public ResponseEntity<ResultResDto> login(
 		@Valid @RequestBody LoginDto loginDto,
 		HttpServletRequest request
 	) {
 		// 로그인 결과
-		ResponseEntity<LoginResDto> loginResult = loginService.login(loginDto, request);
+		ResponseEntity<ResultResDto> loginResult = loginService.login(loginDto, request);
 
 		return loginResult;
 	}
 
 	// 자동 로그인
 	@GetMapping("/token")
-	public ResponseEntity<LoginResDto> autoLogin(HttpServletRequest request) {
+	public ResponseEntity<ResultResDto> autoLogin(HttpServletRequest request) {
 		// 로그인 결과
-		ResponseEntity<LoginResDto> loginResult = loginService.autoLogin(request);
+		ResponseEntity<ResultResDto> loginResult = loginService.autoLogin(request);
 
 		return loginResult;
 	}

--- a/src/main/java/com/musicq/musicqservice/member/dto/MemberImageDto.java
+++ b/src/main/java/com/musicq/musicqservice/member/dto/MemberImageDto.java
@@ -4,13 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class MemberImageDto {
-
     private String uuid;
     @Builder.Default
     private String path = "default";

--- a/src/main/java/com/musicq/musicqservice/member/dto/MemberInfoDto.java
+++ b/src/main/java/com/musicq/musicqservice/member/dto/MemberInfoDto.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class MemberSignUpDto {
+public class MemberInfoDto {
     @NotNull
     private String id;
 
@@ -27,6 +27,7 @@ public class MemberSignUpDto {
     private String password;
 
     @Builder.Default
-    private final MemberImageDto memberImageDto = MemberImageDto.builder().build();
+    @Setter
+    private MemberImageDto memberImage = MemberImageDto.builder().build();
 
 }

--- a/src/main/java/com/musicq/musicqservice/member/dto/ResultResDto.java
+++ b/src/main/java/com/musicq/musicqservice/member/dto/ResultResDto.java
@@ -1,7 +1,6 @@
 package com.musicq.musicqservice.member.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,6 +9,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class LoginResDto {
+public class ResultResDto {
 	String result;
 }

--- a/src/main/java/com/musicq/musicqservice/member/service/LoginService.java
+++ b/src/main/java/com/musicq/musicqservice/member/service/LoginService.java
@@ -4,14 +4,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.musicq.musicqservice.member.dto.LoginDto;
-import com.musicq.musicqservice.member.dto.LoginResDto;
+import com.musicq.musicqservice.member.dto.ResultResDto;
 
 import jakarta.servlet.http.HttpServletRequest;
 
 @Service
 public interface LoginService {
-	ResponseEntity<LoginResDto> login(LoginDto loginDto, HttpServletRequest request);
-	ResponseEntity<LoginResDto> autoLogin(HttpServletRequest request);
+	ResponseEntity<ResultResDto> login(LoginDto loginDto, HttpServletRequest request);
+	ResponseEntity<ResultResDto> autoLogin(HttpServletRequest request);
 
 	String checkPassword(String id);
 	ResponseEntity<String> checkId(String id);

--- a/src/main/java/com/musicq/musicqservice/member/service/LoginServiceImpl.java
+++ b/src/main/java/com/musicq/musicqservice/member/service/LoginServiceImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import com.musicq.musicqservice.member.dto.LoginDto;
-import com.musicq.musicqservice.member.dto.LoginResDto;
+import com.musicq.musicqservice.member.dto.ResultResDto;
 import com.musicq.musicqservice.member.util.Encoder;
 import com.musicq.musicqservice.member.util.TokenProvider;
 
@@ -36,7 +36,7 @@ public class LoginServiceImpl implements LoginService {
 
 	// 로컬 로그인
 	@Override
-	public ResponseEntity<LoginResDto> login(LoginDto loginDto, HttpServletRequest request) {
+	public ResponseEntity<ResultResDto> login(LoginDto loginDto, HttpServletRequest request) {
 		// Cookie 에 Access Token 존재 여부
 		String accessToken = chkTokenInCookie(request);
 
@@ -46,7 +46,7 @@ public class LoginServiceImpl implements LoginService {
 		HttpStatus status = HttpStatus.UNAUTHORIZED;
 
 		// body에 출력할 login에 대한 결과
-		LoginResDto loginResDto = new LoginResDto();
+		ResultResDto resultResDto = new ResultResDto();
 
 		// Cookie에 Access Token이 없는 경우
 		if (accessToken == null) {
@@ -80,18 +80,18 @@ public class LoginServiceImpl implements LoginService {
 
 						// 결과
 						status = HttpStatus.OK;
-						loginResDto.setResult("Success");
+						resultResDto.setResult("Success");
 					} else {
 						status = HttpStatus.BAD_REQUEST;
-						loginResDto.setResult("교통사고");
+						resultResDto.setResult("교통사고");
 					}
 				} else {
 					// 입력된 ID가 존재하나 그 ID에 해당되는 PW와 입력한 PW가 일치하지 않는 경우
-					loginResDto.setResult("Wrong PW");
+					resultResDto.setResult("Wrong PW");
 				}
 			} else if (idCount == 0) {
 				// id가 존재하지 않는 경우
-				loginResDto.setResult("Wrong ID");
+				resultResDto.setResult("Wrong ID");
 			} else {
 				// id count가 1과 0이 아니면 이미 중복된 회원이 생겨버린 것
 				log.warn("회원 중복되어 있어 이미 이멀전씌");
@@ -100,16 +100,16 @@ public class LoginServiceImpl implements LoginService {
 			log.warn("Cookie에 AccessToken이 있으면 login Controller로 오면 안돼용");
 		}
 
-		log.warn(loginResDto);
+		log.warn(resultResDto);
 
 		// 로그인 성공 결과와 헤더에 Cookie 생성 후 AccessToken 발급
-		return new ResponseEntity<>(loginResDto, httpHeaders, status);
+		return new ResponseEntity<>(resultResDto, httpHeaders, status);
 	}
 
 	// 자동 로그인
 	// 로그인 유효기간(1일)이 지나지 않았다면 자동로그인을 해주고, 1일을 연장해준다.
 	@Override
-	public ResponseEntity<LoginResDto> autoLogin(HttpServletRequest request) {
+	public ResponseEntity<ResultResDto> autoLogin(HttpServletRequest request) {
 		// Cookie에 Access Token 존재 여부
 		String tokenInCookie = chkTokenInCookie(request);
 
@@ -120,7 +120,7 @@ public class LoginServiceImpl implements LoginService {
 		HttpStatus status = HttpStatus.UNAUTHORIZED;
 
 		// body에 출력할 login에 대한 결과
-		LoginResDto loginResDto = new LoginResDto();
+		ResultResDto resultResDto = new ResultResDto();
 
 		// Cookie에 Access Token이 있다면
 		if (tokenInCookie != null) {
@@ -139,16 +139,16 @@ public class LoginServiceImpl implements LoginService {
 					if(redisSaveToken) {
 						// 결과
 						status = HttpStatus.OK;
-						loginResDto.setResult("Auto Login Success");
+						resultResDto.setResult("Auto Login Success");
 					} else {
 						status = HttpStatus.BAD_REQUEST;
-						loginResDto.setResult("교통사고");
+						resultResDto.setResult("교통사고");
 					}
 				} else {
 					// Redis에 존재하지 않는다면 로그인 유효기간이 지났단 뜻이므로 일반 로그인으로 리다이렉트
 					// 이 응답 코드는 요청한 리소스의 URI가 일시적으로 변경되었음을 의미
 					status = HttpStatus.FOUND;
-					loginResDto.setResult("Login Redirect");
+					resultResDto.setResult("Login Redirect");
 				}
 			} else {
 				log.warn("토큰에 해당하는 id가 없다고?");
@@ -157,10 +157,10 @@ public class LoginServiceImpl implements LoginService {
 			log.warn("Cookie에 Access Token이 존재해야 자동 로그인 가능해용");
 		}
 
-		log.warn(loginResDto);
+		log.warn(resultResDto);
 
 		// 자동 로그인 성공 결과 반환
-		return new ResponseEntity<>(loginResDto, status);
+		return new ResponseEntity<>(resultResDto, status);
 	}
 
 	// id 존재 여부

--- a/src/main/java/com/musicq/musicqservice/member/service/MemberService.java
+++ b/src/main/java/com/musicq/musicqservice/member/service/MemberService.java
@@ -1,17 +1,17 @@
 package com.musicq.musicqservice.member.service;
 
-import com.musicq.musicqservice.member.dto.LoginDto;
-import com.musicq.musicqservice.member.dto.MemberSignUpDto;
-import com.musicq.musicqservice.member.dto.TokenDto;
+import com.musicq.musicqservice.member.dto.MemberInfoDto;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface MemberService {
-	ResponseEntity<String> signup(MemberSignUpDto memberSignUpDto);
+	ResponseEntity<String> signup(MemberInfoDto memberInfoDto);
 
 	ResponseEntity<String> memberInfoCheck(String id);
+
+	ResponseEntity<Object> memberInfoChange(String id, MemberInfoDto memberInfoDto);
 
 	ResponseEntity<String> unregister(String id);
 
@@ -19,5 +19,5 @@ public interface MemberService {
 
 	ResponseEntity<String> checkEmail(String email);
 
-	ResponseEntity<String> checkNickname(String nickname);
+	ResponseEntity<String> checkNickname(String id, String nickname);
 }

--- a/src/main/java/com/musicq/musicqservice/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/musicq/musicqservice/member/service/MemberServiceImpl.java
@@ -1,15 +1,22 @@
 package com.musicq.musicqservice.member.service;
 
-import com.musicq.musicqservice.member.dto.MemberSignUpDto;
+import com.musicq.musicqservice.member.dto.MemberInfoDto;
+import com.musicq.musicqservice.member.dto.ResultResDto;
 import com.musicq.musicqservice.member.util.Encoder;
+import com.musicq.musicqservice.member.util.UploaderLocal;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
+import org.json.JSONObject;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @Log4j2
@@ -20,10 +27,11 @@ public class MemberServiceImpl implements MemberService {
 
 	// 회원 가입
 	@Override
-	public ResponseEntity<String> signup(MemberSignUpDto memberSignUpDto) {
-		memberSignUpDto.setPassword(Encoder.encodeStr(memberSignUpDto.getPassword()));
+	public ResponseEntity<String> signup(MemberInfoDto memberInfoDto) {
+
+		memberInfoDto.setPassword(Encoder.encodeStr(memberInfoDto.getPassword()));
 		ResponseEntity<String> response = restTemplate.postForEntity("http://localhost:81/v1/members/member",
-			memberSignUpDto, String.class);
+			memberInfoDto, String.class);
 		log.info(response.getStatusCode());
 		log.info(response.getHeaders());
 		log.info(response.getBody());
@@ -38,7 +46,46 @@ public class MemberServiceImpl implements MemberService {
 		log.info(response.getStatusCode());
 		log.info(response.getHeaders());
 		log.info(response.getBody());
+		return response;
+	}
 
+	// 회원 정보 수정
+	@Override
+	public ResponseEntity<Object> memberInfoChange(String id, MemberInfoDto memberInfoDto) {
+		ResponseEntity<Object> response = null;
+		try {
+			JSONObject jsonNicknameInfo = new JSONObject(
+				checkNickname(memberInfoDto.getId(), memberInfoDto.getNickname()).getBody());
+			// DB 에 사용자가 입력한 닉네임의 개수
+			String nickNameCount = jsonNicknameInfo.getString("count");
+
+			// 현재 사용자(id 기준)의 DB에 저장된 닉네임
+			String currentNickname = jsonNicknameInfo.getString("currentNickname");
+
+			// 닉네임이 중복되는지 React에서도 물어보지만 Spring에 서도 한번 더 유효성 검사
+			// count 가 1 이여도 현재 닉네임에서 변경하지 않고 그대로 request를 보내도 본인의 닉네임에 대해서는 허용
+			if (nickNameCount.equals("0") || memberInfoDto.getNickname().equals(currentNickname)) {
+
+				// 그냥 restTemplate.put은 반환 값이 없어서 exchange 함수를 사용해서 반환값을 받기 위해서 헤더와 요청 body를 생성
+				HttpHeaders headers = new HttpHeaders();
+				headers.setContentType(MediaType.APPLICATION_JSON);
+				HttpEntity<MemberInfoDto> request = new HttpEntity<>(memberInfoDto, headers);
+
+				response = restTemplate.exchange("http://localhost:81/v1/members/member/{id}", HttpMethod.PUT,
+					request, Object.class, id);
+			} else {
+				ResultResDto failResponse = new ResultResDto("Exist Nickname");
+				log.warn("이 에러 발생 시 React에서 Nickname 중복확인 요청 없이 회원가입 요청을 진행한 것.");
+				return ResponseEntity.internalServerError().body(failResponse);
+			}
+
+		} catch (NullPointerException | HttpServerErrorException | HttpClientErrorException e) {
+			log.warn(e.getStackTrace());
+			log.warn(e.getMessage());
+			log.warn("React 에서 값 잘못 준거임 ㅅㄱ.");
+			ResultResDto failResponse = new ResultResDto("Invalid Variable");
+			return ResponseEntity.badRequest().body(failResponse);
+		}
 		return response;
 	}
 
@@ -81,9 +128,9 @@ public class MemberServiceImpl implements MemberService {
 
 	// nickname 존재여부
 	@Override
-	public ResponseEntity<String> checkNickname(String nickname) {
+	public ResponseEntity<String> checkNickname(String id, String nickname) {
 		ResponseEntity<String> response = restTemplate.getForEntity(
-			"http://localhost:81/v1/members/nickname/{nickname}", String.class, nickname);
+			"http://localhost:81/v1/members/nickname/{id}/{nickname}", String.class, id, nickname);
 		log.info(response.getStatusCode());
 		log.info(response.getHeaders());
 		log.info(response.getBody());

--- a/src/main/java/com/musicq/musicqservice/member/util/TokenProvider.java
+++ b/src/main/java/com/musicq/musicqservice/member/util/TokenProvider.java
@@ -1,7 +1,6 @@
 package com.musicq.musicqservice.member.util;
 
 import java.security.Key;
-import java.util.Date;
 
 import org.json.JSONObject;
 import org.springframework.beans.factory.InitializingBean;
@@ -74,21 +73,4 @@ public class TokenProvider implements InitializingBean {
 			return e.getClaims();
 		}
 	}
-
-	// refresh 토큰 발급 메서드 - 아마 사용안할 듯?
-	/*public String createRefreshToken(ResponseEntity<String> response){
-		long now = (new Date()).getTime();
-		Date refreshValidity = new Date(now + this.refreshTokenValidityInMilliseconds * 1000);
-
-		JSONObject jsonId = new JSONObject(response.getBody());
-		String subId = jsonId.getString("id");
-
-		String refreshToken = Jwts.builder()
-			.setSubject(subId)
-			.setExpiration(refreshValidity)
-			.signWith(key, SignatureAlgorithm.HS256)
-			.compact();
-
-		return refreshToken;
-	}*/
 }

--- a/src/main/java/com/musicq/musicqservice/member/util/UploaderLocal.java
+++ b/src/main/java/com/musicq/musicqservice/member/util/UploaderLocal.java
@@ -1,0 +1,96 @@
+package com.musicq.musicqservice.member.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.musicq.musicqservice.member.dto.MemberImageDto;
+import com.musicq.musicqservice.member.dto.ResultResDto;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Component
+public class UploaderLocal {
+	@Value("${MusicQ-Default_Profile_Img_Path}")
+	private String uploadPath;
+
+	@Value("${MusicQ-Default_Profile_Img_Name}")
+	private String defaultImgName;
+
+
+	// 로컬에 디렉토리 생성하는 함수
+	public String createLocalUploadDir(){
+		String dirName = "uploadImg";
+
+		File uploadPathDir = new File(uploadPath, dirName);
+		// 디렉토리가 없는 경우 생성
+		if(!uploadPathDir.exists()){
+			uploadPathDir.mkdirs();
+		}
+		return dirName;
+	}
+
+	// 파일 업로드
+	public ResponseEntity<Object> uploadToLocal(MultipartFile[] uploadFiles){
+		MemberImageDto result = new MemberImageDto();
+		try {
+			for(MultipartFile uploadFile : uploadFiles){
+				// 이미지 파일이 아니라면 업로드 수행 X
+				if(!Objects.requireNonNull(uploadFile.getContentType()).startsWith("image")){
+					log.warn("이미지 파일이 아닌 업로드.");
+					ResultResDto failResponse = new ResultResDto("File is not Image");
+					return ResponseEntity.badRequest().body(failResponse);
+				}
+
+				// 업로드 된 파일의 실제 이름
+				String originalName = uploadFile.getOriginalFilename();
+
+				// originalName에는 로컬 경로에 저장된 파일의 경로를 포함해서 가져오기 때문에 파일이름.확장자 형식을 추출하기위해
+				String fileName = originalName.substring(originalName.lastIndexOf("\\")+1);
+
+
+				log.warn(originalName, fileName);
+
+				// 이미지 업로드 할 디렉토리 생성
+				String realUploadDir = createLocalUploadDir();
+
+				// UUID 생성
+				String uuid = UUID.randomUUID().toString();
+
+				//저장할 파일 이름 중간에 _를 이용해서 구분
+				String saveName = uploadPath + realUploadDir + uuid + fileName;
+
+				File saveFile = new File(saveName);
+
+				try{
+					uploadFile.transferTo(saveFile);
+
+					result.setUuid(uuid);
+					result.setPath(uploadPath + File.separator + realUploadDir);
+					result.setProfile_img(fileName);
+
+				} catch (IOException e ){
+					log.warn(e.getMessage());
+					log.warn(e.getStackTrace());
+					log.warn("Upload Failed");
+					ResultResDto failResponse = new ResultResDto("Upload Failed");
+					return ResponseEntity.badRequest().body(failResponse);
+				}
+			}
+		}catch (NullPointerException e){
+			log.warn(e.getStackTrace());
+			log.warn(e.getMessage());
+			ResultResDto failResponse = new ResultResDto("Upload Failed");
+			return ResponseEntity.badRequest().body(failResponse);
+		}
+		log.info("Upload Success");
+		return ResponseEntity.ok(result);
+	}
+}

--- a/src/main/java/com/musicq/musicqservice/member/util/UploderS3.java
+++ b/src/main/java/com/musicq/musicqservice/member/util/UploderS3.java
@@ -1,0 +1,88 @@
+package com.musicq.musicqservice.member.util;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.musicq.musicqservice.member.dto.MemberImageDto;
+import com.musicq.musicqservice.member.dto.ResultResDto;
+
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class UploderS3 {
+	private final AmazonS3Client amazonS3Client;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	// 파일 업로드
+	public ResponseEntity<?> uploadToS3(MultipartFile uploadFile) {
+		MemberImageDto result = new MemberImageDto();
+
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentType(uploadFile.getContentType());
+		objectMetadata.setContentLength(uploadFile.getSize());
+
+		try {
+			// 이미지 파일이 아니라면 업로드 수행 X
+			if (!Objects.requireNonNull(uploadFile.getContentType()).startsWith("image")) {
+				log.warn("이미지 파일이 아닌 업로드.");
+				ResultResDto failedResult = new ResultResDto("Wrong Extension");
+				return ResponseEntity.badRequest().body(failedResult);
+			}
+
+			// 업로드 된 파일의 실제 이름
+			String originalName = uploadFile.getOriginalFilename();
+
+			// IE 는 파일이름이 아니고 전체 경로를 전송하기 때문에 마지막 \ 부분만 추출한다.
+			String fileName = originalName.substring(originalName.lastIndexOf("\\") + 1);
+
+			log.warn(originalName, fileName);
+
+			// 이미지 업로드 S3 내 카테고리 생성
+			String S3UploadCategory = "UserImg/";
+
+			// UUID 생성
+			String uuid = UUID.randomUUID().toString();
+
+			String saveName = S3UploadCategory + uuid + fileName;
+
+			try (InputStream inputStream = uploadFile.getInputStream()){
+				amazonS3Client.putObject(new PutObjectRequest(bucket, saveName, inputStream, objectMetadata).withCannedAcl(
+					CannedAccessControlList.PublicRead));
+				result.setUuid(uuid);
+				result.setPath(amazonS3Client.getUrl(bucket, S3UploadCategory).toString());
+				result.setProfile_img(fileName);
+
+			} catch (NullPointerException | IOException | AmazonS3Exception | IllegalArgumentException | SecurityException e){
+				log.warn(e.getStackTrace());
+				log.warn(e.getMessage());
+				ResultResDto failResponse = new ResultResDto("Upload Failed");
+				return ResponseEntity.badRequest().body(failResponse);
+			}
+
+		} catch (NullPointerException e) {
+			log.warn(e.getStackTrace());
+			log.warn(e.getMessage());
+			ResultResDto failResponse = new ResultResDto("Upload Failed");
+			return ResponseEntity.badRequest().body(failResponse);
+		}
+		log.info("Upload Success");
+		return ResponseEntity.ok(result);
+	}
+}


### PR DESCRIPTION
[✨feat: 회원 정보 수정](https://dreamkakao.atlassian.net/jira/software/projects/DRKKO/boards/1/backlog?selectedIssue=DRKKO-38)

1. MemberImageDto 에서 Setter로 값들을 바꿔줘야하므로 변경(S3이면 S3경로, 로컬이면 로컬 경로 와 UUID, 파일의 진짜 이름)
2. MemberInfoDto 내에 MemberImageDto도 값을 변경해주어야 하므로 Setter 추가
3. 회원 정보 수정 시 변경하고자 하는 닉네임의 Count가 0이거나 Count가 1이여도 입력한 닉네임이 현재 닉네임과 같다면 변경이 가능하도록 설정
4. 회원 정보 수정시 Nickname Count 를 요청하던 메서드가 현재 사용자의 id를 같이 가져가서 사용자가 입력한 Nickname의 Count 개수와 현재 id가 가진 Nickname을 반환하도록 변경
5. 기존의 Login에 대해서 Success OR Failed를 반환하던 LoginResDto를 다른 로직에서도 이용하게 되어서 ResultResDto 로 이름 변경
6. 로컬 환경에서 프로필 이미지를 업로드 했을 때 처리할 UploderLocal 클래스 추가
7. S3 환경에 프로필 이미지를 업로드 했을 때 처리할 UploadS3 클래스를 추가하고 AmazoneS3Client 를 사용하기 위해서 AwsS3Config 클래스와 의존성 추가
8. 기존의 회원가입 시 기본으로 설정되는 프로필 이미지 처리를 실제로 기본 이미지의 경로를 갖도록 수정 필요 -> 회원 가입 시 이메일 인증을 처리할 브랜치에서 같이 처리할 예정
9. 패스워드 수정을 회원 정보 수정으로 부터 분리했기 때문에 지라에 추가 후 새로운 브랜치에서 작업할 예정

[DRKKO-38]: https://dreamkakao.atlassian.net/browse/DRKKO-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ